### PR TITLE
Prefer RPIT over explicitly naming types

### DIFF
--- a/non_contiguously_indexed_array/src/array.rs
+++ b/non_contiguously_indexed_array/src/array.rs
@@ -39,7 +39,7 @@ impl<I: NciIndex, V> std::ops::Index<I> for NciArray<'_, I, V> {
     }
 }
 
-pub struct NciArrayIndexIter<'a, I: NciIndex> {
+struct NciArrayIndexIter<'a, I: NciIndex> {
     index_range_starting_indices: &'a [I],
     index_range_skip_amounts: &'a [I],
     index: I,

--- a/non_contiguously_indexed_array/src/array.rs
+++ b/non_contiguously_indexed_array/src/array.rs
@@ -124,12 +124,12 @@ impl<I: NciIndex> Iterator for NciArrayIndexIter<'_, I> {
 }
 
 impl<I: NciIndex, V> NciArray<'_, I, V> {
-    pub fn values(&self) -> core::slice::Iter<'_, V> {
+    pub fn values(&self) -> impl Iterator<Item = &V> {
         self.values.iter()
     }
 
-    #[must_use] 
-    pub fn indices(&self) -> NciArrayIndexIter<'_, I> {
+    #[must_use]
+    pub fn indices(&self) -> impl Iterator<Item = I> {
         NciArrayIndexIter::new(
             self.index_range_starting_indices,
             self.index_range_skip_amounts,
@@ -137,7 +137,7 @@ impl<I: NciIndex, V> NciArray<'_, I, V> {
         )
     }
 
-    pub fn entries(&self) -> std::iter::Zip<NciArrayIndexIter<'_, I>, core::slice::Iter<'_, V>> {
+    pub fn entries(&self) -> impl Iterator<Item = (I, &V)> {
         self.indices().zip(self.values())
     }
 

--- a/non_contiguously_indexed_array/tests/basic_tests.rs
+++ b/non_contiguously_indexed_array/tests/basic_tests.rs
@@ -4,7 +4,7 @@ use constants::*;
 #[test]
 fn basic_array_test_1() {
     let arr = ARRAY_1;
-    let values_as_slice = arr.values().as_slice();
+    let values_as_slice = arr.values().copied().collect::<Vec<_>>();
     assert_eq!(values_as_slice, ARRAY_1.values);
 
     assert_eq!(arr.get(0), Some(&0));
@@ -25,7 +25,7 @@ fn basic_array_test_1() {
 #[test]
 fn basic_array_test_2() {
     let arr = ARRAY_2;
-    let values_as_slice = arr.values().as_slice();
+    let values_as_slice = arr.values().copied().collect::<Vec<_>>();
     assert_eq!(values_as_slice, ARRAY_2.values);
 
     assert_eq!(arr.get(0), None);


### PR DESCRIPTION
Using RPIT (return position impl trait) has the following benefits over explicitly naming the return type:
- No breaking change when changing the underlying iterator implementation.
- Less verbose return type that is easier to understand.

It also has drawbacks:
- The exposed interface has less functionality.

In case you are unfamiliar with RPIT, this video explains it nicely:
https://youtu.be/CWiz_RtA1Hw?t=62&si=wHtPvvn-s49mFPPP