### PR TITLE
Rework inner workings of `NciArray` and implement `NciIndex` trait for all primitive numeric types

### DIFF
--- a/non_contiguously_indexed_array/src/array.rs
+++ b/non_contiguously_indexed_array/src/array.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, Clone, Copy, Default)]
-pub struct NciArray<'a, I: NciIndex, V> {
+pub struct NciArray<'a, I, V> {
     /// The user-defined index of the first element of each segment.
     /// Example: `segments_idx_begin[2] == 5` means the first element of the third segment has user-defined index 5.
     pub segments_idx_begin: &'a [I],
@@ -10,6 +10,16 @@ pub struct NciArray<'a, I: NciIndex, V> {
 
     /// All the values stored in this array.
     pub values: &'a [V],
+}
+
+impl<'a, I, V> NciArray<'_, I, V> {
+    pub const fn new() -> Self {
+        Self {
+            segments_idx_begin: &[],
+            segments_mem_idx_begin: &[],
+            values: &[],
+        }
+    }
 }
 
 pub trait NciIndex:

--- a/non_contiguously_indexed_array/src/array.rs
+++ b/non_contiguously_indexed_array/src/array.rs
@@ -1,3 +1,4 @@
+#[derive(Debug, Clone, Copy, Default)]
 pub struct NciArray<'a, I: NciIndex, V> {
     /// The user-defined index of the first element of each segment.
     /// Example: `segments_idx_begin[2] == 5` means the first element of the third segment has user-defined index 5.

--- a/non_contiguously_indexed_array/src/index.rs
+++ b/non_contiguously_indexed_array/src/index.rs
@@ -1,4 +1,4 @@
-pub trait NciIndex: Ord + PartialOrd + Sized + Clone + Copy {
+pub trait NciIndex: Ord + Copy {
     /// Return the next index after this one, or `None` if this is the maximum possible index.
     fn next(self) -> Option<Self>;
 

--- a/non_contiguously_indexed_array/src/index.rs
+++ b/non_contiguously_indexed_array/src/index.rs
@@ -1,0 +1,18 @@
+pub trait NciIndex: Ord + PartialOrd + Sized + Clone + Copy {
+    /// Return the next index after this one, or `None` if this is the maximum possible index.
+    fn next(self) -> Option<Self>;
+
+    /// Return the distance between `self` and `other` in case `self <= other`.
+    /// If `self > other` or the distance is greater than `usize::MAX`, return `None`.
+    fn distance(self, other: Self) -> Option<usize>;
+}
+
+impl NciIndex for u32 {
+    fn next(self) -> Option<Self> {
+        self.checked_add(1)
+    }
+
+    fn distance(self, other: Self) -> Option<usize> {
+        other.checked_sub(self)?.try_into().ok()
+    }
+}

--- a/non_contiguously_indexed_array/src/index.rs
+++ b/non_contiguously_indexed_array/src/index.rs
@@ -25,9 +25,3 @@ impl_index_trait_for_primitive_num!(u16);
 impl_index_trait_for_primitive_num!(u32);
 impl_index_trait_for_primitive_num!(u64);
 impl_index_trait_for_primitive_num!(u128);
-
-impl_index_trait_for_primitive_num!(i8);
-impl_index_trait_for_primitive_num!(i16);
-impl_index_trait_for_primitive_num!(i32);
-impl_index_trait_for_primitive_num!(i64);
-impl_index_trait_for_primitive_num!(i128);

--- a/non_contiguously_indexed_array/src/index.rs
+++ b/non_contiguously_indexed_array/src/index.rs
@@ -7,12 +7,27 @@ pub trait NciIndex: Ord + PartialOrd + Sized + Clone + Copy {
     fn distance(self, other: Self) -> Option<usize>;
 }
 
-impl NciIndex for u32 {
-    fn next(self) -> Option<Self> {
-        self.checked_add(1)
-    }
-
-    fn distance(self, other: Self) -> Option<usize> {
-        other.checked_sub(self)?.try_into().ok()
-    }
+macro_rules! impl_index_trait_for_primitive_num {
+    ($t:ty) => {
+        impl NciIndex for $t {
+            fn next(self) -> Option<Self> {
+                self.checked_add(1)
+            }
+            fn distance(self, other: Self) -> Option<usize> {
+                other.checked_sub(self)?.try_into().ok()
+            }
+        }
+    };
 }
+
+impl_index_trait_for_primitive_num!(u8);
+impl_index_trait_for_primitive_num!(u16);
+impl_index_trait_for_primitive_num!(u32);
+impl_index_trait_for_primitive_num!(u64);
+impl_index_trait_for_primitive_num!(u128);
+
+impl_index_trait_for_primitive_num!(i8);
+impl_index_trait_for_primitive_num!(i16);
+impl_index_trait_for_primitive_num!(i32);
+impl_index_trait_for_primitive_num!(i64);
+impl_index_trait_for_primitive_num!(i128);

--- a/non_contiguously_indexed_array/src/index.rs
+++ b/non_contiguously_indexed_array/src/index.rs
@@ -2,8 +2,8 @@ pub trait NciIndex: Ord + Copy {
     /// Return the next index after this one, or `None` if this is the maximum possible index.
     fn next(self) -> Option<Self>;
 
-    /// Return the distance between `self` and `other` in case `self <= other`.
-    /// If `self > other` or the distance is greater than `usize::MAX`, return `None`.
+    /// Return the distance between `self` and `other`.
+    /// If the distance is greater than `usize::MAX`, return `None`.
     fn distance(self, other: Self) -> Option<usize>;
 }
 
@@ -14,7 +14,7 @@ macro_rules! impl_index_trait_for_primitive_num {
                 self.checked_add(1)
             }
             fn distance(self, other: Self) -> Option<usize> {
-                other.checked_sub(self)?.try_into().ok()
+                self.abs_diff(other).try_into().ok()
             }
         }
     };
@@ -25,3 +25,9 @@ impl_index_trait_for_primitive_num!(u16);
 impl_index_trait_for_primitive_num!(u32);
 impl_index_trait_for_primitive_num!(u64);
 impl_index_trait_for_primitive_num!(u128);
+
+impl_index_trait_for_primitive_num!(i8);
+impl_index_trait_for_primitive_num!(i16);
+impl_index_trait_for_primitive_num!(i32);
+impl_index_trait_for_primitive_num!(i64);
+impl_index_trait_for_primitive_num!(i128);

--- a/non_contiguously_indexed_array/src/lib.rs
+++ b/non_contiguously_indexed_array/src/lib.rs
@@ -1,2 +1,5 @@
 mod array;
 pub use array::*;
+
+mod index;
+pub use index::*;

--- a/non_contiguously_indexed_array/tests/constants.rs
+++ b/non_contiguously_indexed_array/tests/constants.rs
@@ -1,19 +1,20 @@
 use non_contiguously_indexed_array::NciArray;
 
 pub const ARRAY_1: NciArray<u32, u32> = NciArray {
-    index_range_starting_indices: &[0, 10, 100],
-    index_range_skip_amounts: &[0, 7, 95],
+    segments_idx_begin: &[0, 10, 100],
+    segments_mem_idx_begin: &[0, 3, 5],
     values: &[0, 1, 2, 10, 11, 100],
 };
+
 pub const ARRAY_2: NciArray<u32, u32> = NciArray {
-    index_range_starting_indices: &[100, 200, 500],
-    index_range_skip_amounts: &[100, 198, 497],
+    segments_idx_begin: &[100, 200, 500],
+    segments_mem_idx_begin: &[0, 2, 3],
     values: &[100, 101, 200, 500, 501, 502],
 };
 
 #[test]
 fn test_constants_1() {
-    assert_eq!(ARRAY_1.index_range_starting_indices.len(), 3);
-    assert_eq!(ARRAY_1.index_range_skip_amounts.len(), 3);
+    assert_eq!(ARRAY_1.segments_idx_begin.len(), 3);
+    assert_eq!(ARRAY_1.segments_mem_idx_begin.len(), 3);
     assert_eq!(ARRAY_1.values.len(), 6);
 }

--- a/non_contiguously_indexed_array_builder/Cargo.toml
+++ b/non_contiguously_indexed_array_builder/Cargo.toml
@@ -14,9 +14,4 @@ workspace = true
 crate-type = ["rlib"]
 
 [dependencies]
-log = { version = "0.4", optional = true}
 non_contiguously_indexed_array = { workspace = true }
-
-[features]
-default = ["log"]
-log = ["dep:log", "log/std"]

--- a/non_contiguously_indexed_array_builder/src/builder.rs
+++ b/non_contiguously_indexed_array_builder/src/builder.rs
@@ -1,11 +1,6 @@
 use non_contiguously_indexed_array::NciIndex;
 
 pub struct NciArrayBuilder<I: NciIndex, V> {
-    entries_ordered_monotonically_increasing: bool,
-    last_added_entry_index: Option<I>,
-    // Values of the format (start_index, skipped_since_last).
-    // The skip amounts are relative to the previous range as opposed to the final NciArray where they are absolute
-    index_ranges: Vec<(I, I)>,
     entries: Vec<(I, V)>,
 }
 
@@ -38,78 +33,22 @@ impl<I: NciIndex + std::fmt::Debug, V: std::fmt::Display + std::fmt::Debug> Defa
 impl<I: NciIndex + std::fmt::Debug, V: std::fmt::Display + std::fmt::Debug> NciArrayBuilder<I, V> {
     #[must_use]
     pub const fn new() -> Self {
-        Self {
-            entries_ordered_monotonically_increasing: true,
-            last_added_entry_index: None,
-            index_ranges: vec![],
-            entries: vec![],
-        }
+        Self { entries: vec![] }
     }
 
     pub fn entry(&mut self, index: I, value: V) {
-        if self.entries_ordered_monotonically_increasing {
-            if let Some(last_added_entry_index) = self.last_added_entry_index {
-                if index > last_added_entry_index {
-                    let index_difference = index - last_added_entry_index;
-                    if index_difference != I::ONE {
-                        self.index_ranges.push((index, index_difference - I::ONE));
-                    }
-                } else {
-                    if index == last_added_entry_index {
-                        #[cfg(feature = "log")]
-                        log::warn!("Duplicate index `{index:?}` with new value `{value:?}`");
-                    }
-                    self.entries_ordered_monotonically_increasing = false;
-                }
-            } else {
-                self.index_ranges.push((index, index));
-            }
-
-            self.last_added_entry_index = Some(index);
-            if !self.entries_ordered_monotonically_increasing {
-                self.last_added_entry_index = None;
-                self.index_ranges = vec![];
-            }
-        }
-
+        // #[cfg(feature = "log")]
+        // log::warn!("Duplicate index `{index:?}` with new value `{value:?}`");
         self.entries.push((index, value));
     }
 
     fn ensure_output_preconditions(&mut self) {
-        if !self.entries_ordered_monotonically_increasing {
-            self.entries
-                .sort_by(|(first_index, _), (second_index, _)| first_index.cmp(second_index));
-            {
-                // filter duplicate entries, first entry with index is retained
-                let mut expected_index = self.entries.first().unwrap().0;
-                self.entries.retain(|(entry_index, _)| {
-                    let index_as_expected = *entry_index == expected_index;
-                    if index_as_expected {
-                        expected_index += I::ONE;
-                    }
-                    index_as_expected
-                });
+        self.entries.sort_by_key(|(index, _value)| *index);
+        for window in self.entries.windows(2) {
+            if window[0].0 == window[1].0 {
+                panic!("Duplicate indices detected");
+                // TODO: better panic message
             }
-
-            for (index, value) in &self.entries {
-                if let Some(last_added_entry_index) = self.last_added_entry_index {
-                    if *index > last_added_entry_index {
-                        let index_difference = *index - last_added_entry_index;
-                        if index_difference != I::ONE {
-                            self.index_ranges.push((*index, index_difference - I::ONE));
-                        }
-                    } else {
-                        #[cfg(feature = "log")]
-                        log::warn!("Duplicate index `{index:?}` with new value `{value:?}`");
-                    }
-                } else {
-                    self.index_ranges.push((*index, *index));
-                }
-
-                self.last_added_entry_index = Some(*index);
-            }
-
-            self.entries_ordered_monotonically_increasing = true;
         }
     }
 
@@ -117,6 +56,16 @@ impl<I: NciIndex + std::fmt::Debug, V: std::fmt::Display + std::fmt::Debug> NciA
         use std::fmt::Write as _;
 
         self.ensure_output_preconditions();
+
+        let mut segments_idx_begin = Vec::new();
+        let mut segments_mem_idx_begin = Vec::new();
+
+        for mem_idx in 0..self.entries.len() {
+            if mem_idx == 0 || self.entries[mem_idx - 1].0 + I::ONE != self.entries[mem_idx].0 {
+                segments_idx_begin.push(self.entries[mem_idx].0);
+                segments_mem_idx_begin.push(mem_idx);
+            }
+        }
 
         let (struct_opening_str, struct_closing_str, array_opening_str, array_closing_str) =
             match build_config.output_format {
@@ -132,13 +81,13 @@ impl<I: NciIndex + std::fmt::Debug, V: std::fmt::Display + std::fmt::Debug> NciA
 
         write!(
             output_string,
-            "{indentation_str}index_range_starting_indices:{space_str}{array_opening_str}{new_line_str}"
+            "{indentation_str}segments_idx_begin:{space_str}{array_opening_str}{new_line_str}"
         )
         .unwrap();
-        for (i, (starting_index, _)) in self.index_ranges.iter().enumerate() {
+        for (i, idx_begin) in segments_idx_begin.iter().enumerate() {
             let comma_str = match build_config.output_format {
                 OutputFormat::RON => {
-                    if i == self.index_ranges.len() - 1 {
+                    if i == segments_idx_begin.len() - 1 {
                         ""
                     } else {
                         ","
@@ -149,7 +98,7 @@ impl<I: NciIndex + std::fmt::Debug, V: std::fmt::Display + std::fmt::Debug> NciA
             write!(
                 output_string,
                 "{indentation_str}{indentation_str}{:?}{comma_str}{new_line_str}",
-                *starting_index
+                *idx_begin
             )
             .unwrap();
         }
@@ -161,14 +110,13 @@ impl<I: NciIndex + std::fmt::Debug, V: std::fmt::Display + std::fmt::Debug> NciA
 
         write!(
             output_string,
-            "{indentation_str}index_range_skip_amounts:{space_str}{array_opening_str}{new_line_str}"
+            "{indentation_str}segments_mem_idx_begin:{space_str}{array_opening_str}{new_line_str}"
         )
         .unwrap();
-        let mut total_skip_amount = I::ZERO;
-        for (i, (_, skip_amount)) in self.index_ranges.iter().enumerate() {
+        for (i, mem_idx_begin) in segments_mem_idx_begin.iter().enumerate() {
             let comma_str = match build_config.output_format {
                 OutputFormat::RON => {
-                    if i == self.index_ranges.len() - 1 {
+                    if i == segments_mem_idx_begin.len() - 1 {
                         ""
                     } else {
                         ","
@@ -176,10 +124,10 @@ impl<I: NciIndex + std::fmt::Debug, V: std::fmt::Display + std::fmt::Debug> NciA
                 }
                 _ => ",",
             };
-            total_skip_amount += *skip_amount;
             write!(
                 output_string,
-                "{indentation_str}{indentation_str}{total_skip_amount:?}{comma_str}{new_line_str}"
+                "{indentation_str}{indentation_str}{:?}{comma_str}{new_line_str}",
+                *mem_idx_begin
             )
             .unwrap();
         }

--- a/non_contiguously_indexed_array_builder/src/builder.rs
+++ b/non_contiguously_indexed_array_builder/src/builder.rs
@@ -61,7 +61,14 @@ impl<I: NciIndex + std::fmt::Debug, V: std::fmt::Display + std::fmt::Debug> NciA
         let mut segments_mem_idx_begin = Vec::new();
 
         for mem_idx in 0..self.entries.len() {
-            if mem_idx == 0 || self.entries[mem_idx - 1].0 + I::ONE != self.entries[mem_idx].0 {
+            let new_segment = if mem_idx == 0 {
+                true
+            } else {
+                let prv_entry_idx = self.entries[mem_idx - 1].0;
+                let cur_entry_idx = self.entries[mem_idx].0;
+                prv_entry_idx.distance(cur_entry_idx) != Some(1)
+            };
+            if new_segment {
                 segments_idx_begin.push(self.entries[mem_idx].0);
                 segments_mem_idx_begin.push(mem_idx);
             }

--- a/non_contiguously_indexed_array_builder/tests/constants.rs
+++ b/non_contiguously_indexed_array_builder/tests/constants.rs
@@ -1,19 +1,20 @@
 use non_contiguously_indexed_array::NciArray;
 
 pub const ARRAY_1: NciArray<u32, u32> = NciArray {
-    index_range_starting_indices: &[0, 10, 100],
-    index_range_skip_amounts: &[0, 7, 95],
+    segments_idx_begin: &[0, 10, 100],
+    segments_mem_idx_begin: &[0, 3, 5],
     values: &[0, 1, 2, 10, 11, 100],
 };
+
 pub const ARRAY_2: NciArray<u32, u32> = NciArray {
-    index_range_starting_indices: &[100, 200, 500],
-    index_range_skip_amounts: &[100, 198, 497],
+    segments_idx_begin: &[100, 200, 500],
+    segments_mem_idx_begin: &[0, 2, 3],
     values: &[100, 101, 200, 500, 501, 502],
 };
 
 #[test]
 fn test_constants_1() {
-    assert_eq!(ARRAY_1.index_range_starting_indices.len(), 3);
-    assert_eq!(ARRAY_1.index_range_skip_amounts.len(), 3);
+    assert_eq!(ARRAY_1.segments_idx_begin.len(), 3);
+    assert_eq!(ARRAY_1.segments_mem_idx_begin.len(), 3);
     assert_eq!(ARRAY_1.values.len(), 6);
 }

--- a/non_contiguously_indexed_array_builder/tests/generated/test_generated_1.rs
+++ b/non_contiguously_indexed_array_builder/tests/generated/test_generated_1.rs
@@ -1,15 +1,15 @@
 use non_contiguously_indexed_array::NciArray;
 
 pub const GENERATED_1: NciArray<u32, u32> = NciArray {
-	index_range_starting_indices: &[
+	segments_idx_begin: &[
 		0,
 		10,
 		100,
 	],
-	index_range_skip_amounts: &[
+	segments_mem_idx_begin: &[
 		0,
-		7,
-		95,
+		3,
+		5,
 	],
 	values: &[
 		0,

--- a/non_contiguously_indexed_array_builder/tests/generated/test_generated_2.rs
+++ b/non_contiguously_indexed_array_builder/tests/generated/test_generated_2.rs
@@ -1,15 +1,15 @@
 use non_contiguously_indexed_array::NciArray;
 
 pub const GENERATED_2: NciArray<u32, u32> = NciArray {
-	index_range_starting_indices: &[
+	segments_idx_begin: &[
 		100,
 		200,
 		500,
 	],
-	index_range_skip_amounts: &[
-		100,
-		198,
-		497,
+	segments_mem_idx_begin: &[
+		0,
+		2,
+		3,
 	],
 	values: &[
 		100,


### PR DESCRIPTION
For `NciArray` and `NciIndex`, it might be easier to review just the new content instead of comparing it against previous code as most of the code has been replaced.

This PR changes how `NciArray` works internally to support using any *unsigned* primitive numeric type as the index (yes, even when the index type is larger than `usize`).