### PR TITLE
Optimize `NciArrayIndexIter` and implement `Iterator::size_hint`

### DIFF
--- a/non_contiguously_indexed_array/src/array.rs
+++ b/non_contiguously_indexed_array/src/array.rs
@@ -94,6 +94,7 @@ impl<I: NciIndex, V> NciArray<'_, I, V> {
     }
 
     pub fn indices(&self) -> impl Iterator<Item = I> {
+        #[allow(clippy::option_if_let_else)] // Using map_or as suggested makes it unreadable
         if let Ok(mem_idx_end) = std::num::NonZero::try_from(self.values.len()) {
             // This assert improves performance by having a single panic check instead of
             // having separate panic checks for each of the indexing operations below.


### PR DESCRIPTION
Optimized the implementation of `Iterator::next` and implemented `Iterator::size_hint`.

Assembly of old implementation (after compiler optimizations):

```asm
<example::OldNciArrayIndexIter<I> as core::iter::traits::iterator::Iterator>::next::h5255f1f2dff6f35a:
        xor     eax, eax
        cmp     dword ptr [rdi], 1
        jne     .LBB3_2
        mov     rcx, qword ptr [rdi + 48]
        test    rcx, rcx
        je      .LBB3_2
        mov     edx, dword ptr [rdi + 4]
        dec     rcx
        mov     qword ptr [rdi + 48], rcx
        mov     rcx, qword ptr [rdi + 32]
        test    rcx, rcx
        je      .LBB3_5
        mov     rsi, qword ptr [rdi + 24]
        mov     rax, qword ptr [rdi + 40]
        inc     rax
        cmp     rax, qword ptr [rsi]
        jne     .LBB3_7
        mov     r8, qword ptr [rdi + 16]
        test    r8, r8
        je      .LBB3_10
        mov     r9, qword ptr [rdi + 8]
        lea     r10, [r9 + 4]
        dec     r8
        mov     qword ptr [rdi + 8], r10
        mov     qword ptr [rdi + 16], r8
        mov     r8d, dword ptr [r9]
        mov     r9d, 1
        jmp     .LBB3_12
.LBB3_2:
        ret
.LBB3_5:
        mov     rax, qword ptr [rdi + 40]
        inc     rax
.LBB3_7:
        xor     ecx, ecx
        cmp     edx, -1
        setne   cl
        lea     esi, [rdx + 1]
        mov     dword ptr [rdi], ecx
        mov     dword ptr [rdi + 4], esi
        mov     qword ptr [rdi + 40], rax
        mov     eax, 1
        ret
.LBB3_10:
        xor     r9d, r9d
.LBB3_12:
        mov     dword ptr [rdi], r9d
        mov     dword ptr [rdi + 4], r8d
        add     rsi, 8
        dec     rcx
        mov     qword ptr [rdi + 24], rsi
        mov     qword ptr [rdi + 32], rcx
        mov     qword ptr [rdi + 40], rax
        mov     eax, 1
        ret
```

Assembly of new implementation:

```asm
<example::NciArrayIndexIter<I> as core::iter::traits::iterator::Iterator>::next::h2760789cf71b0410:
        mov     rax, qword ptr [rdi]
        test    rax, rax
        je      .LBB2_4
        mov     edx, dword ptr [rdi + 48]
        mov     r8, qword ptr [rdi + 40]
        inc     r8
        cmp     r8, qword ptr [rdi + 32]
        je      .LBB2_3
        mov     ecx, edx
        inc     ecx
        jne     .LBB2_5
.LBB2_3:
        mov     qword ptr [rdi], 0
        mov     eax, 1
        ret
.LBB2_4:
        xor     eax, eax
        ret
.LBB2_5:
        mov     qword ptr [rdi + 40], r8
        mov     rsi, qword ptr [rdi + 24]
        test    rsi, rsi
        je      .LBB2_9
        mov     r9, qword ptr [rdi + 16]
        cmp     r8, qword ptr [r9]
        jne     .LBB2_9
        mov     r8, qword ptr [rdi + 8]
        test    r8, r8
        je      .LBB2_9
        add     r9, 8
        dec     rsi
        mov     qword ptr [rdi + 16], r9
        mov     qword ptr [rdi + 24], rsi
        lea     rcx, [rax + 4]
        dec     r8
        mov     qword ptr [rdi], rcx
        mov     qword ptr [rdi + 8], r8
        mov     ecx, dword ptr [rax]
.LBB2_9:
        mov     dword ptr [rdi + 48], ecx
        mov     eax, 1
        ret
```

The new implementation also slightly reduces the memory footprint of the iterator in some cases:
```rust
assert_eq!(size_of::<NciArrayIndexIter::<'static, u64>>(), 56);
assert_eq!(size_of::<OldNciArrayIndexIter::<'static, u64>>(), 64);
```

Godbolt: https://godbolt.org/z/erfra3axj