### PR TITLE
Implement `ExactSizeIterator` for all iterators

### DIFF
--- a/non_contiguously_indexed_array/src/array.rs
+++ b/non_contiguously_indexed_array/src/array.rs
@@ -76,6 +76,16 @@ impl<I: NciIndex> Iterator for NciArrayIndexIter<'_, I> {
             NciArrayIndexIter::Empty => None,
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = match self {
+            NciArrayIndexIter::NonEmpty(iter_data) => {
+                iter_data.mem_idx_end.get() - iter_data.current_mem_idx
+            }
+            NciArrayIndexIter::Empty => 0,
+        };
+        (remaining, Some(remaining))
+    }
 }
 
 impl<I: NciIndex, V> NciArray<'_, I, V> {

--- a/non_contiguously_indexed_array/src/array.rs
+++ b/non_contiguously_indexed_array/src/array.rs
@@ -94,6 +94,7 @@ impl<I: NciIndex, V> NciArray<'_, I, V> {
     }
 
     pub fn indices(&self) -> impl Iterator<Item = I> {
+        #[allow(clippy::option_if_let_else)] // Using map_or as suggested makes it unreadable
         if let Ok(mem_idx_end) = std::num::NonZero::try_from(self.values.len()) {
             // This assert improves performance by having a single panic check instead of
             // having separate panic checks for each of the indexing operations below.

--- a/non_contiguously_indexed_array/src/array.rs
+++ b/non_contiguously_indexed_array/src/array.rs
@@ -33,15 +33,15 @@ impl<I: NciIndex, V> core::ops::Index<I> for NciArray<'_, I, V> {
 }
 
 impl<I: NciIndex, V> NciArray<'_, I, V> {
-    pub fn values(&self) -> impl Iterator<Item = &V> + ExactSizeIterator {
+    pub fn values(&self) -> impl ExactSizeIterator<Item = &V> {
         self.values.iter()
     }
 
-    pub fn indices(&self) -> impl Iterator<Item = I> + ExactSizeIterator {
+    pub fn indices(&self) -> impl ExactSizeIterator<Item = I> {
         NciArrayIndexIter::new(self)
     }
 
-    pub fn entries(&self) -> impl Iterator<Item = (I, &V)> + ExactSizeIterator {
+    pub fn entries(&self) -> impl ExactSizeIterator<Item = (I, &V)> {
         self.indices().zip(self.values())
     }
 

--- a/non_contiguously_indexed_array/src/array.rs
+++ b/non_contiguously_indexed_array/src/array.rs
@@ -32,34 +32,48 @@ impl<I: NciIndex, V> std::ops::Index<I> for NciArray<'_, I, V> {
     }
 }
 
-struct NciArrayIndexIter<'a, I: NciIndex> {
-    current_idx: Option<I>,
+struct NciArrayIndexIterData<'a, I> {
+    current_idx: I,
     current_mem_idx: usize,
     remaining_idx_begin: &'a [I],
     remaining_mem_idx_begin: &'a [usize],
-    remaining_items: usize,
+    mem_idx_end: std::num::NonZero<usize>,
+}
+
+enum NciArrayIndexIter<'a, I> {
+    NonEmpty(NciArrayIndexIterData<'a, I>),
+    Empty,
 }
 
 impl<I: NciIndex> Iterator for NciArrayIndexIter<'_, I> {
     type Item = I;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(current_idx) = self.current_idx
-            && self.remaining_items > 0
-        {
-            self.remaining_items -= 1;
-            if let Some(next_mem_idx) = self.remaining_mem_idx_begin.first()
-                && self.current_mem_idx + 1 == *next_mem_idx
-            {
-                self.current_idx = self.remaining_idx_begin.split_off_first().copied();
-                self.current_mem_idx = *self.remaining_mem_idx_begin.split_off_first().unwrap();
-            } else {
-                self.current_idx = current_idx.next();
-                self.current_mem_idx += 1;
+        match self {
+            NciArrayIndexIter::NonEmpty(iter_data) => {
+                let result = iter_data.current_idx;
+                let next_mem_idx = iter_data.current_mem_idx + 1;
+                if next_mem_idx != iter_data.mem_idx_end.get()
+                    && let Some(next_idx) = result.next()
+                {
+                    iter_data.current_mem_idx = next_mem_idx;
+                    iter_data.current_idx = if let Some(next_segment_mem_idx) =
+                        iter_data.remaining_mem_idx_begin.first()
+                        && next_mem_idx == *next_segment_mem_idx
+                        && !iter_data.remaining_idx_begin.is_empty()
+                    {
+                        // Jump to next segment
+                        iter_data.remaining_mem_idx_begin.split_off_first();
+                        *iter_data.remaining_idx_begin.split_off_first().unwrap()
+                    } else {
+                        next_idx
+                    };
+                } else {
+                    *self = NciArrayIndexIter::Empty;
+                }
+                Some(result)
             }
-            Some(current_idx)
-        } else {
-            None
+            NciArrayIndexIter::Empty => None,
         }
     }
 }
@@ -70,14 +84,19 @@ impl<I: NciIndex, V> NciArray<'_, I, V> {
     }
 
     pub fn indices(&self) -> impl Iterator<Item = I> {
-        let idx_split = self.segments_idx_begin.split_first();
-        let mem_idx_split = self.segments_mem_idx_begin.split_first();
-        NciArrayIndexIter {
-            current_idx: idx_split.map(|split| *split.0),
-            current_mem_idx: mem_idx_split.map(|split| *split.0).unwrap_or_default(),
-            remaining_idx_begin: idx_split.map(|split| split.1).unwrap_or_default(),
-            remaining_mem_idx_begin: mem_idx_split.map(|split| split.1).unwrap_or_default(),
-            remaining_items: self.values.len(),
+        if let Ok(mem_idx_end) = std::num::NonZero::try_from(self.values.len()) {
+            // This assert improves performance by having a single panic check instead of
+            // having separate panic checks for each of the indexing operations below.
+            assert!(!self.segments_idx_begin.is_empty() && !self.segments_mem_idx_begin.is_empty());
+            NciArrayIndexIter::NonEmpty(NciArrayIndexIterData {
+                current_idx: self.segments_idx_begin[0],
+                current_mem_idx: 0,
+                remaining_idx_begin: &self.segments_idx_begin[1..],
+                remaining_mem_idx_begin: &self.segments_mem_idx_begin[1..],
+                mem_idx_end,
+            })
+        } else {
+            NciArrayIndexIter::Empty
         }
     }
 

--- a/non_contiguously_indexed_array/src/array.rs
+++ b/non_contiguously_indexed_array/src/array.rs
@@ -33,15 +33,15 @@ impl<I: NciIndex, V> std::ops::Index<I> for NciArray<'_, I, V> {
 }
 
 impl<I: NciIndex, V> NciArray<'_, I, V> {
-    pub fn values(&self) -> impl Iterator<Item = &V> {
+    pub fn values(&self) -> impl Iterator<Item = &V> + ExactSizeIterator {
         self.values.iter()
     }
 
-    pub fn indices(&self) -> impl Iterator<Item = I> {
+    pub fn indices(&self) -> impl Iterator<Item = I> + ExactSizeIterator {
         NciArrayIndexIter::new(self)
     }
 
-    pub fn entries(&self) -> impl Iterator<Item = (I, &V)> {
+    pub fn entries(&self) -> impl Iterator<Item = (I, &V)> + ExactSizeIterator {
         self.indices().zip(self.values())
     }
 

--- a/non_contiguously_indexed_array/src/iter.rs
+++ b/non_contiguously_indexed_array/src/iter.rs
@@ -41,9 +41,7 @@ impl<I: NciIndex> Iterator for NciArrayIndexIter<'_, I> {
             NciArrayIndexIter::NonEmpty(iter_data) => {
                 let result = iter_data.current_idx;
                 let next_mem_idx = iter_data.current_mem_idx + 1;
-                if next_mem_idx != iter_data.mem_idx_end.get()
-                    && let Some(next_idx) = result.next()
-                {
+                if next_mem_idx != iter_data.mem_idx_end.get() {
                     iter_data.current_mem_idx = next_mem_idx;
                     iter_data.current_idx = if let Some(next_segment_mem_idx) =
                         iter_data.remaining_mem_idx_begin.first()
@@ -54,7 +52,10 @@ impl<I: NciIndex> Iterator for NciArrayIndexIter<'_, I> {
                         iter_data.remaining_mem_idx_begin.split_off_first();
                         *iter_data.remaining_idx_begin.split_off_first().unwrap()
                     } else {
-                        next_idx
+                        // If the data structure was properly constructed, `result.next()` should never yield `None` here.
+                        // Using `unwrap_or` here is a deliberate decision to avoid generating a panic handler
+                        // and also ensures that the iterator always returns exactly `self.len()` elements.
+                        result.next().unwrap_or(result)
                     };
                 } else {
                     *self = NciArrayIndexIter::Empty;

--- a/non_contiguously_indexed_array/src/iter.rs
+++ b/non_contiguously_indexed_array/src/iter.rs
@@ -5,7 +5,7 @@ pub struct NciArrayIndexIterData<'a, I> {
     current_mem_idx: usize,
     remaining_idx_begin: &'a [I],
     remaining_mem_idx_begin: &'a [usize],
-    mem_idx_end: std::num::NonZero<usize>,
+    mem_idx_end: core::num::NonZero<usize>,
 }
 
 pub enum NciArrayIndexIter<'a, I> {
@@ -16,7 +16,7 @@ pub enum NciArrayIndexIter<'a, I> {
 impl<'a, I: NciIndex> NciArrayIndexIter<'a, I> {
     pub fn new<V>(arr: &'a NciArray<'_, I, V>) -> Self {
         #[allow(clippy::option_if_let_else)] // Using map_or as suggested makes it unreadable
-        if let Ok(mem_idx_end) = std::num::NonZero::try_from(arr.values.len()) {
+        if let Ok(mem_idx_end) = core::num::NonZero::try_from(arr.values.len()) {
             // This assert improves performance by having a single panic check instead of
             // having separate panic checks for each of the indexing operations below.
             assert!(!arr.segments_idx_begin.is_empty() && !arr.segments_mem_idx_begin.is_empty());

--- a/non_contiguously_indexed_array/src/iter.rs
+++ b/non_contiguously_indexed_array/src/iter.rs
@@ -66,12 +66,18 @@ impl<I: NciIndex> Iterator for NciArrayIndexIter<'_, I> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = match self {
+        let remaining = self.len();
+        (remaining, Some(remaining))
+    }
+}
+
+impl<I: NciIndex> ExactSizeIterator for NciArrayIndexIter<'_, I> {
+    fn len(&self) -> usize {
+        match self {
             NciArrayIndexIter::NonEmpty(iter_data) => {
                 iter_data.mem_idx_end.get() - iter_data.current_mem_idx
             }
             NciArrayIndexIter::Empty => 0,
-        };
-        (remaining, Some(remaining))
+        }
     }
 }

--- a/non_contiguously_indexed_array/src/iter.rs
+++ b/non_contiguously_indexed_array/src/iter.rs
@@ -1,0 +1,77 @@
+use crate::{NciArray, NciIndex};
+
+pub struct NciArrayIndexIterData<'a, I> {
+    current_idx: I,
+    current_mem_idx: usize,
+    remaining_idx_begin: &'a [I],
+    remaining_mem_idx_begin: &'a [usize],
+    mem_idx_end: std::num::NonZero<usize>,
+}
+
+pub enum NciArrayIndexIter<'a, I> {
+    NonEmpty(NciArrayIndexIterData<'a, I>),
+    Empty,
+}
+
+impl<'a, I: NciIndex> NciArrayIndexIter<'a, I> {
+    pub fn new<V>(arr: &'a NciArray<'_, I, V>) -> Self {
+        #[allow(clippy::option_if_let_else)] // Using map_or as suggested makes it unreadable
+        if let Ok(mem_idx_end) = std::num::NonZero::try_from(arr.values.len()) {
+            // This assert improves performance by having a single panic check instead of
+            // having separate panic checks for each of the indexing operations below.
+            assert!(!arr.segments_idx_begin.is_empty() && !arr.segments_mem_idx_begin.is_empty());
+            NciArrayIndexIter::NonEmpty(NciArrayIndexIterData {
+                current_idx: arr.segments_idx_begin[0],
+                current_mem_idx: 0,
+                remaining_idx_begin: &arr.segments_idx_begin[1..],
+                remaining_mem_idx_begin: &arr.segments_mem_idx_begin[1..],
+                mem_idx_end,
+            })
+        } else {
+            NciArrayIndexIter::Empty
+        }
+    }
+}
+
+impl<I: NciIndex> Iterator for NciArrayIndexIter<'_, I> {
+    type Item = I;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            NciArrayIndexIter::NonEmpty(iter_data) => {
+                let result = iter_data.current_idx;
+                let next_mem_idx = iter_data.current_mem_idx + 1;
+                if next_mem_idx != iter_data.mem_idx_end.get()
+                    && let Some(next_idx) = result.next()
+                {
+                    iter_data.current_mem_idx = next_mem_idx;
+                    iter_data.current_idx = if let Some(next_segment_mem_idx) =
+                        iter_data.remaining_mem_idx_begin.first()
+                        && next_mem_idx == *next_segment_mem_idx
+                        && !iter_data.remaining_idx_begin.is_empty()
+                    {
+                        // Jump to next segment
+                        iter_data.remaining_mem_idx_begin.split_off_first();
+                        *iter_data.remaining_idx_begin.split_off_first().unwrap()
+                    } else {
+                        next_idx
+                    };
+                } else {
+                    *self = NciArrayIndexIter::Empty;
+                }
+                Some(result)
+            }
+            NciArrayIndexIter::Empty => None,
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = match self {
+            NciArrayIndexIter::NonEmpty(iter_data) => {
+                iter_data.mem_idx_end.get() - iter_data.current_mem_idx
+            }
+            NciArrayIndexIter::Empty => 0,
+        };
+        (remaining, Some(remaining))
+    }
+}

--- a/non_contiguously_indexed_array/src/lib.rs
+++ b/non_contiguously_indexed_array/src/lib.rs
@@ -3,3 +3,6 @@ pub use array::*;
 
 mod index;
 pub use index::*;
+
+mod iter;
+use iter::*;


### PR DESCRIPTION
Also moved `NciArrayIndexIter` to its own module for clarity.